### PR TITLE
Fix documentation build

### DIFF
--- a/cgen/doc/running.texi
+++ b/cgen/doc/running.texi
@@ -16,8 +16,6 @@ The main tasks of this script are to:
 @item Apply any post processing to the output files.
 @end enumerate
 
-@subsection Set up the arguments for cgen.
-
 CGEN takes several standard arguments.
 Each application can then add its own arguments.
 By convention generic CGEN options are lowercase letters


### PR DESCRIPTION
My version of `makeinfo` (5.2) fails to build the documentation when the `@subsection` tag removed in this patch is present:

```
$ make info
restore=: && backupdir=".am$$" && \
        rm -rf $backupdir && mkdir $backupdir && \
        if (makeinfo --split-size=5000000 --version) >/dev/null 2>&1; then \
          for f in cgen.info cgen.info-[0-9] cgen.info-[0-9][0-9] cgen.i[0-9] cgen.i[0-9][0-9]; do \
            if test -f $f; then mv $f $backupdir; restore=mv; else :; fi; \
          done; \
        else :; fi && \
        if makeinfo --split-size=5000000   -I ../.././cgen/doc \
         -o cgen.info `test -f 'cgen.texi' || echo '../.././cgen/doc/'`cgen.texi; \
        then \
          rc=0; \
        else \
          rc=$?; \
          $restore $backupdir/* `echo "./cgen.info" | sed 's|[^/]*$||'`; \
        fi; \
        rm -rf $backupdir; exit $rc
./running.texi:19: raising the section level of @subsection which is too low
make: *** [cgen.info] Error 1
$
```
